### PR TITLE
Add CI workflow (lint, build, Lighthouse)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Lint & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          retention-days: 7
+
+  lighthouse:
+    name: Lighthouse CI
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Run Lighthouse CI
+        run: npx --yes @lhci/cli@0.13.x autorun
+        continue-on-error: true


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` so the README's CI claim is no longer aspirational.

**Two jobs** triggered on push to `main` and on PRs:

1. **Lint & build** — `npm install` → `npm run lint` (continue-on-error so existing style nits don't block) → `npm run build` (Webpack production). Uploads the `dist/` artifact for 7 days.
2. **Lighthouse CI** — depends on build job. Runs `@lhci/cli autorun` against the existing `lighthouserc.js` config (which already targets `./dist` with desktop preset and asserts on performance/accessibility/best-practices/SEO). Set to `continue-on-error` so the first run doesn't fail builds while you tune the thresholds.

**Notes:**
- Pinned to Node 20 (no .nvmrc in repo).
- Uses `npm install` because there's no `package-lock.json`. Worth running `npm install` locally and committing the lockfile in a follow-up — that lets us switch to the faster, deterministic `npm ci`.
- Permissions limited to `contents: read` (no write needed).
- `package.json`'s `license` field still reads `"SEE LICENSE IN LICENSE.md"` — should be updated to `"MIT"` after PR #5 (the license rename) merges. Not included here to keep PRs focused.

PR 4 of 5 in the GitHub profile cleanup.